### PR TITLE
Fix crash on iPad

### DIFF
--- a/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/CropViewController.swift
+++ b/Example/Pods/iOSPhotoEditor/Photo Editor/Photo Editor/CropViewController.swift
@@ -145,6 +145,7 @@ open class CropViewController: UIViewController {
     
     func constrain(_ sender: UIBarButtonItem) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.popoverPresentationController?.barButtonItem = sender
         let original = UIAlertAction(title: "Original", style: .default) { [unowned self] action in
             guard let image = self.cropView?.image else {
                 return


### PR DESCRIPTION
Without presentation controller actionSheet fails on iPad with uncaught exception:

[ Uncaught Exception ]
Name: NSGenericException, Reason: Your application has presented a UIAlertController (<UIAlertController:>) of style UIAlertControllerStyleActionSheet. The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.